### PR TITLE
Fix some typos in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@ Allows you to define what attributes in your Eloquent Model which should be not 
 
 ## Installing
 
-Install using Composer `composer require larapack/attribute-purging 1.*`.
+Install using Composer `composer require larapack/attribute-purging`.
 
 ## Usage
 
@@ -13,7 +13,7 @@ First add the trait `Purgeable` to your Eloquent Model.
 
 namespace App;
 
-use Larapack/AttributePurgin/Purgeable;
+use Larapack\AttributePurging\Purgeable;
 
 class User
 {


### PR DESCRIPTION
Thanks for the trait - I was about to write it myself, but looked first if there is a package and - voila.

I just fixed some things in the Readme:

1. `composer require larapack/attribute-purging 1.*` does not work, but a simple `composer require larapack/attribute-purging` seems to be enough.

2. We should use backslashes in the use statement and there was a "g" missing.

Cheers, Sebastian